### PR TITLE
feat: 관리자 지원서 조회 API 연동 및 트랙별 지원 목록 조회 페이지 추가

### DIFF
--- a/src/hooks/useApplyList.ts
+++ b/src/hooks/useApplyList.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import { fetchApplyList } from "../services/applyService";
+import { useAuthStore } from "../store/authStore";
+
+interface Apply {
+  applyId: number;
+  name: string;
+  track: string;
+  updatedAt: string;
+}
+
+
+export const useApplyList = (track: string | null) => {
+  const [applyList, setApplyList] = useState<Apply[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    const fetchList = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = await fetchApplyList(accessToken, track);
+        setApplyList(data);
+      } catch (err) {
+        setError("지원서 목록을 조회하는 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchList();
+  }, [track, accessToken]);
+
+  return { applyList, loading, error };
+};

--- a/src/pages/Admin/ApplyListPage.tsx
+++ b/src/pages/Admin/ApplyListPage.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { useAuthStore } from "../../store/authStore";
+
+interface Apply {
+  applyId: number;
+  name: string;
+  track: string;
+  updatedAt: string;
+}
+
+const ApplyListPage = () => {
+  const [applyList, setApplyList] = useState<Apply[]>([]);
+  const [track, setTrack] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    const fetchApplyList = async () => {
+      if (!accessToken) {
+        setError("액세스 토큰이 없습니다.");
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await axios.get<Apply[]>("/api/admin/apply", {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+          params: {
+            track,
+          },
+        });
+
+        // 응답 데이터가 배열인지 확인하고 설정
+        if (Array.isArray(response.data)) {
+          setApplyList(response.data);
+        } else {
+          setApplyList([]);
+        }
+      } catch (err) {
+        setError("지원서 목록을 조회하는 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchApplyList();
+  }, [track, accessToken]);
+
+  return (
+    <div>
+      <h1>지원서 목록</h1>
+      <div>
+        <label htmlFor="track">트랙 선택:</label>
+        <select
+          id="track"
+          value={track || ""}
+          onChange={(e) => setTrack(e.target.value || null)}
+        >
+          <option value="">모든 트랙</option>
+          <option value="UNION">UNION</option>
+          <option value="GAMING_VIDEO">GAMING_VIDEO</option>
+          <option value="SECURITY_WEB">SECURITY_WEB</option>
+          <option value="AI">AI</option>
+          <option value="IOT_ROBOTICS">IOT_ROBOTICS</option>
+          <option value="BIGDATA">BIGDATA</option>
+        </select>
+      </div>
+      {loading && <p>로딩 중...</p>}
+      {error && <p>{error}</p>}
+      <ul>
+        {applyList.map((apply) => (
+          <li key={apply.applyId}>
+            <p>이름: {apply.name}</p>
+            <p>트랙: {apply.track}</p>
+            <p>업데이트 날짜: {new Date(apply.updatedAt).toLocaleString()}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ApplyListPage;

--- a/src/services/applyService.ts
+++ b/src/services/applyService.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+export const fetchApplyList = async (accessToken: string, track: string | null) => {
+  const response = await axios.get("/api/admin/apply", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    params: {
+      track,
+    },
+  });
+
+  return response.data;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 

## 📝작업 내용

>  관리자가 트랙별로 지원자의 목록을 조회할 수 있는 api를 연동하고 트랙별 지원 목록을 조회하는 페이지 추가하였습니다.

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
